### PR TITLE
fix(multiple-runners): machine_autoscaling invalid map key

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -22,7 +22,7 @@ locals {
 
   // Depcrecated off peak, ensure not set if not explicit set.
   runners_off_peak_periods_string = var.runners_off_peak_periods == null ? "" : format("OffPeakPeriods = %s", var.runners_off_peak_periods)
-  runners_off_peak_timezone       = var.runners_off_peak_timezone == null ? "" : "OffPeakTimezone = \"${var.runners_off_peak_timezone}\""
+  runners_off_peak_timezone       = var.runners_off_peak_timezone == null ? "" : format("OffPeakTimezone = \"%s\"", var.runners_off_peak_timezone)
   runners_off_peak_idle_count     = var.runners_off_peak_idle_count == -1 ? "" : format("OffPeakIdleCount = %d", var.runners_off_peak_idle_count)
   runners_off_peak_idle_time      = var.runners_off_peak_idle_time == -1 ? "" : format("OffPeakIdleTime = %d", var.runners_off_peak_idle_time)
 

--- a/main.tf
+++ b/main.tf
@@ -118,9 +118,9 @@ locals {
     idle_count                = var.runners_idle_count
     idle_time                 = var.runners_idle_time
     max_builds                = local.runners_max_builds_string
-    off_peak_timezone         = var.runners_off_peak_timezone
-    off_peak_idle_count       = var.runners_off_peak_idle_count
-    off_peak_idle_time        = var.runners_off_peak_idle_time
+    off_peak_timezone         = local.runners_off_peak_timezone
+    off_peak_idle_count       = local.runners_off_peak_idle_count
+    off_peak_idle_time        = local.runners_off_peak_idle_time
     off_peak_periods_string   = local.runners_off_peak_periods_string
     root_size                 = var.runners_root_size
     iam_instance_profile_name = var.runners_iam_instance_profile_name

--- a/template/runner-config-runners.tpl
+++ b/template/runner-config-runners.tpl
@@ -59,9 +59,8 @@
 %{ endif }
 ${docker_machine_options}
     ]
-
     ${off_peak_timezone}
     ${off_peak_idle_count}
     ${off_peak_idle_time}
     ${off_peak_periods_string}
-${runners_machine_autoscaling}
+${machine_autoscaling}

--- a/variables.tf
+++ b/variables.tf
@@ -269,19 +269,19 @@ variable "runners_environment_vars" {
 variable "runners_pre_build_script" {
   description = "Script to execute in the pipeline just before the build, will be used in the runner config.toml"
   type        = string
-  default     = "\"\""
+  default     = ""
 }
 
 variable "runners_post_build_script" {
   description = "Commands to be executed on the Runner just after executing the build, but before executing after_script. "
   type        = string
-  default     = "\"\""
+  default     = ""
 }
 
 variable "runners_pre_clone_script" {
   description = "Commands to be executed on the Runner before cloning the Git repository. this can be used to adjust the Git client configuration first, for example. "
   type        = string
-  default     = "\"\""
+  default     = ""
 }
 
 variable "runners_request_concurrency" {


### PR DESCRIPTION
## Description
Should resolve the issue with
```bash
Error: Invalid function argument

  on .terraform/modules/gitlab_runner/main.tf line 149, in locals:
 149:     templatefile("${path.module}/template/runner-config-runners.tpl", merge(local.runners_defaults, runner))
    |----------------
    | local.runners_defaults is object with 50 attributes

Invalid value for "vars" parameter: vars map does not contain key
"runners_machine_autoscaling", referenced at
.terraform/modules/gitlab_runner/template/runner-config-runners.tpl:67,3-30.

[terragrunt] 2021/03/18 13:23:21 Hit multiple errors:
exit status 1
```

I think this is some sort of rebase mistake

## Migrations required
NO
